### PR TITLE
Feat: added tests for signature checker functions

### DIFF
--- a/flex_marketplace/src/marketplace/signature_checker2.cairo
+++ b/flex_marketplace/src/marketplace/signature_checker2.cairo
@@ -65,8 +65,10 @@ mod SignatureChecker2 {
             order_signature: Array<felt252>
         ) {
             let hash = self.compute_maker_order_hash(hash_domain, order);
-            ISRC6CamelOnlyDispatcher { contract_address: order.signer }
+            let result = ISRC6CamelOnlyDispatcher { contract_address: order.signer }
                 .isValidSignature(hash, order_signature);
+
+            assert!(result == starknet::VALIDATED, "SignatureChecker: Invalid signature");
         }
     }
 }

--- a/flex_marketplace/tests/marketplace_test.cairo
+++ b/flex_marketplace/tests/marketplace_test.cairo
@@ -3,13 +3,13 @@ use tests::utils::{
     setup, initialize_test, deploy_mock_nft, ACCOUNT1, ACCOUNT2, OWNER, ZERO_ADDRESS, RELAYER,
     deploy_mock_execution_strategy, deploy_mock_account, deploy_mock_erc20, E18
 };
-use snforge_std::signature::stark_curve::{
-    StarkCurveKeyPairImpl, StarkCurveSignerImpl
-};
+use snforge_std::signature::stark_curve::{StarkCurveKeyPairImpl, StarkCurveSignerImpl};
 use flex::marketplace::execution_manager::{
     IExecutionManagerDispatcher, IExecutionManagerDispatcherTrait
 };
-use flex::marketplace::signature_checker2::{ISignatureChecker2Dispatcher, ISignatureChecker2DispatcherTrait};
+use flex::marketplace::signature_checker2::{
+    ISignatureChecker2Dispatcher, ISignatureChecker2DispatcherTrait
+};
 use flex::marketplace::marketplace::{IMarketPlaceDispatcher, IMarketPlaceDispatcherTrait};
 use flex::marketplace::utils::order_types::{MakerOrder, TakerOrder};
 use flex::DefaultContractAddress;
@@ -71,8 +71,10 @@ fn test_match_ask_with_taker_bid_success() {
     maker_order.strategy = mocks.strategy;
     maker_order.currency = mocks.erc20;
 
-    let maker_order_hash = dsp.signature_checker.compute_maker_order_hash(dsp.marketplace.get_hash_domain(), maker_order);
-    
+    let maker_order_hash = dsp
+        .signature_checker
+        .compute_maker_order_hash(dsp.marketplace.get_hash_domain(), maker_order);
+
     let (r, s): (felt252, felt252) = mocks.key_pair.sign(maker_order_hash);
 
     let mut taker_bid: TakerOrder = Default::default();
@@ -137,8 +139,10 @@ fn test_match_bid_with_taker_ask_success() {
     maker_bid.strategy = mocks.strategy;
     maker_bid.currency = mocks.erc20;
 
-    let maker_order_hash = dsp.signature_checker.compute_maker_order_hash(dsp.marketplace.get_hash_domain(), maker_bid);
-    
+    let maker_order_hash = dsp
+        .signature_checker
+        .compute_maker_order_hash(dsp.marketplace.get_hash_domain(), maker_bid);
+
     let (r, s): (felt252, felt252) = mocks.key_pair.sign(maker_order_hash);
 
     let mut taker_ask: TakerOrder = Default::default();
@@ -207,7 +211,9 @@ fn test_execute_auction_sale_success() {
     maker_ask.collection = mocks.erc721;
     maker_ask.currency = mocks.erc20;
 
-    let maker_ask_hash = dsp.signature_checker.compute_maker_order_hash(dsp.marketplace.get_hash_domain(), maker_ask);
+    let maker_ask_hash = dsp
+        .signature_checker
+        .compute_maker_order_hash(dsp.marketplace.get_hash_domain(), maker_ask);
 
     let (r1, s1): (felt252, felt252) = mocks.key_pair.sign(maker_ask_hash);
 
@@ -218,7 +224,9 @@ fn test_execute_auction_sale_success() {
     maker_bid.amount = 1;
     maker_bid.currency = mocks.erc20;
 
-    let maker_bid_hash = dsp.signature_checker.compute_maker_order_hash(dsp.marketplace.get_hash_domain(), maker_bid);
+    let maker_bid_hash = dsp
+        .signature_checker
+        .compute_maker_order_hash(dsp.marketplace.get_hash_domain(), maker_bid);
 
     let (r2, s2): (felt252, felt252) = mocks.key_pair.sign(maker_bid_hash);
 

--- a/flex_marketplace/tests/signature_checker2_test.cairo
+++ b/flex_marketplace/tests/signature_checker2_test.cairo
@@ -1,10 +1,11 @@
 use tests::utils::{setup, initialize_test};
 use poseidon::poseidon_hash_span;
 
-use snforge_std::signature::stark_curve::{
-    StarkCurveKeyPairImpl, StarkCurveSignerImpl
+use snforge_std::signature::stark_curve::{StarkCurveKeyPairImpl, StarkCurveSignerImpl};
+use flex::marketplace::signature_checker2::{
+    ISignatureChecker2Dispatcher, ISignatureChecker2DispatcherTrait, STARKNET_MESSAGE,
+    HASH_MESSAGE_SELECTOR
 };
-use flex::marketplace::signature_checker2::{ISignatureChecker2Dispatcher, ISignatureChecker2DispatcherTrait,STARKNET_MESSAGE, HASH_MESSAGE_SELECTOR};
 use flex::marketplace::utils::order_types::MakerOrder;
 
 #[test]
@@ -40,7 +41,10 @@ fn test_compute_maker_order_hash_success(hash_domain: felt252) {
 
     let order_hash = poseidon_hash_span(hash_params.span());
 
-    assert(order_hash == dsp.signature_checker.compute_maker_order_hash(hash_domain, maker_order), 'Failed hash computation');
+    assert(
+        order_hash == dsp.signature_checker.compute_maker_order_hash(hash_domain, maker_order),
+        'Failed hash computation'
+    );
 }
 
 #[test]
@@ -77,6 +81,6 @@ fn test_verify_maker_order_signature_success(hash_domain: felt252) {
     ];
 
     let order_hash = poseidon_hash_span(hash_params.span());
-    let (r, s) : (felt252, felt252) = mocks.key_pair.sign(order_hash);
+    let (r, s): (felt252, felt252) = mocks.key_pair.sign(order_hash);
     dsp.signature_checker.verify_maker_order_signature(hash_domain, maker_order, array![r, s]);
 }

--- a/flex_marketplace/tests/signature_checker2_test.cairo
+++ b/flex_marketplace/tests/signature_checker2_test.cairo
@@ -1,4 +1,4 @@
-use tests::utils::{setup, initialize_test, deploy_mock_account};
+use tests::utils::{setup, initialize_test};
 use poseidon::poseidon_hash_span;
 
 use snforge_std::signature::stark_curve::{

--- a/flex_marketplace/tests/signature_checker2_test.cairo
+++ b/flex_marketplace/tests/signature_checker2_test.cairo
@@ -1,15 +1,82 @@
-use tests::utils::{setup, initialize_test};
+use tests::utils::{setup, initialize_test, deploy_mock_account};
+use poseidon::poseidon_hash_span;
+
+use snforge_std::signature::stark_curve::{
+    StarkCurveKeyPairImpl, StarkCurveSignerImpl
+};
+use flex::marketplace::signature_checker2::{ISignatureChecker2Dispatcher, ISignatureChecker2DispatcherTrait,STARKNET_MESSAGE, HASH_MESSAGE_SELECTOR};
+use flex::marketplace::utils::order_types::MakerOrder;
 
 #[test]
-fn test_compute_maker_order_hash_success() {
+fn test_compute_maker_order_hash_success(hash_domain: felt252) {
     let dsp = setup();
     initialize_test(dsp);
-// TODO
+
+    let maker_order: MakerOrder = Default::default();
+
+    let hash_message_params = array![
+        HASH_MESSAGE_SELECTOR,
+        maker_order.is_order_ask.into(),
+        maker_order.signer.into(),
+        maker_order.collection.into(),
+        maker_order.price.into(),
+        maker_order.token_id.try_into().unwrap(),
+        maker_order.amount.into(),
+        maker_order.strategy.into(),
+        maker_order.currency.into(),
+        maker_order.nonce.into(),
+        maker_order.start_time.into(),
+        maker_order.end_time.into(),
+        maker_order.min_percentage_to_ask.into(),
+        maker_order.params,
+        14
+    ];
+
+    let hash_message = poseidon_hash_span(hash_message_params.span());
+
+    let hash_params = array![
+        STARKNET_MESSAGE, hash_domain, maker_order.signer.into(), hash_message, 4
+    ];
+
+    let order_hash = poseidon_hash_span(hash_params.span());
+
+    assert(order_hash == dsp.signature_checker.compute_maker_order_hash(hash_domain, maker_order), 'Failed hash computation');
 }
 
 #[test]
-fn test_verify_maker_order_signature_success() {
+fn test_verify_maker_order_signature_success(hash_domain: felt252) {
     let dsp = setup();
-    initialize_test(dsp);
-// TODO
+    let mocks = initialize_test(dsp);
+
+    let mut maker_order: MakerOrder = Default::default();
+
+    maker_order.signer = mocks.account;
+
+    let hash_message_params = array![
+        HASH_MESSAGE_SELECTOR,
+        maker_order.is_order_ask.into(),
+        maker_order.signer.into(),
+        maker_order.collection.into(),
+        maker_order.price.into(),
+        maker_order.token_id.try_into().unwrap(),
+        maker_order.amount.into(),
+        maker_order.strategy.into(),
+        maker_order.currency.into(),
+        maker_order.nonce.into(),
+        maker_order.start_time.into(),
+        maker_order.end_time.into(),
+        maker_order.min_percentage_to_ask.into(),
+        maker_order.params,
+        14
+    ];
+
+    let hash_message = poseidon_hash_span(hash_message_params.span());
+
+    let hash_params = array![
+        STARKNET_MESSAGE, hash_domain, maker_order.signer.into(), hash_message, 4
+    ];
+
+    let order_hash = poseidon_hash_span(hash_params.span());
+    let (r, s) : (felt252, felt252) = mocks.key_pair.sign(order_hash);
+    dsp.signature_checker.verify_maker_order_signature(hash_domain, maker_order, array![r, s]);
 }

--- a/flex_marketplace/tests/utils.cairo
+++ b/flex_marketplace/tests/utils.cairo
@@ -217,8 +217,6 @@ fn initialize_test(dsp: Dispatchers) -> Mocks {
 
     dsp.fee_registry.update_royalty_info_collection(erc721, OWNER(), RECIPIENT(), 1000);
 
-    dsp.currency_manager.add_currency(erc20);
-
     stop_prank(CheatTarget::All(()));
 
     start_prank(CheatTarget::One(erc20), ACCOUNT1());

--- a/flex_marketplace/tests/utils.cairo
+++ b/flex_marketplace/tests/utils.cairo
@@ -6,7 +6,7 @@ use starknet::{
 use snforge_std::{
     PrintTrait, declare, ContractClassTrait, start_warp, start_prank, stop_prank, CheatTarget
 };
-use snforge_std::signature::KeyPairTrait;
+use snforge_std::signature::{KeyPairTrait, KeyPair};
 use snforge_std::signature::stark_curve::{
     StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl
 };
@@ -137,7 +137,7 @@ fn setup() -> Dispatchers {
     }
 }
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Copy, Drop)]
 struct Mocks {
     account: ContractAddress,
     erc20: ContractAddress,
@@ -145,7 +145,8 @@ struct Mocks {
     erc1155: ContractAddress,
     strategy: ContractAddress,
     maker_signature: (felt252, felt252),
-    taker_signature: (felt252, felt252)
+    taker_signature: (felt252, felt252),
+    key_pair: KeyPair<felt252, felt252>,
 }
 
 fn initialize_test(dsp: Dispatchers) -> Mocks {
@@ -233,7 +234,8 @@ fn initialize_test(dsp: Dispatchers) -> Mocks {
         erc1155,
         strategy,
         maker_signature: (r1, s1),
-        taker_signature: (r2, s2)
+        taker_signature: (r2, s2),
+        key_pair
     }
 }
 

--- a/flex_marketplace/tests/utils.cairo
+++ b/flex_marketplace/tests/utils.cairo
@@ -216,6 +216,8 @@ fn initialize_test(dsp: Dispatchers) -> Mocks {
 
     dsp.fee_registry.update_royalty_info_collection(erc721, OWNER(), RECIPIENT(), 1000);
 
+    dsp.currency_manager.add_currency(erc20);
+
     stop_prank(CheatTarget::All(()));
 
     start_prank(CheatTarget::One(erc20), ACCOUNT1());


### PR DESCRIPTION
While writing tests, came across incorrect implementation of `validate_signature`, i have fixed it.

For testing, it was crucial to add `key_pair` in `Mocks` struct to generate signature for orders, so i have added it as well to Mock struct, but it required to remove Serde attribute, as we were not serializing and deserializing it anywhere. If it is needed I can add it and find some other way to use `key_pair` across tests