### PR TITLE
fix: remove deprecated PrintTrait imports to fix build

### DIFF
--- a/marketplace/src/marketplace.cairo
+++ b/marketplace/src/marketplace.cairo
@@ -132,7 +132,6 @@ mod MarketPlace {
     impl ReentrancyGuardInternalImpl = ReentrancyGuardComponent::InternalImpl<ContractState>;
 
 
-    use snforge_std::PrintTrait;
     #[storage]
     struct Storage {
         hash_domain: felt252,

--- a/marketplace/src/mocks/erc20.cairo
+++ b/marketplace/src/mocks/erc20.cairo
@@ -53,7 +53,6 @@ mod ERC20 {
     use integer::BoundedInt;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
-    use snforge_std::PrintTrait;
 
     #[storage]
     struct Storage {

--- a/marketplace/src/transfer_selector_NFT.cairo
+++ b/marketplace/src/transfer_selector_NFT.cairo
@@ -42,7 +42,6 @@ mod TransferSelectorNFT {
     impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
     impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
 
-    use snforge_std::PrintTrait;
 
     #[storage]
     struct Storage {


### PR DESCRIPTION
Reason: PrintTrait was removed in some of the recent `snfoundry` versions so the build failed.
Since it wasn't used, I removed the import