### PR TITLE
POC: ERC-5643 Subscription NFTs

### DIFF
--- a/experimental/erc_5643_subscription_nft/.gitignore
+++ b/experimental/erc_5643_subscription_nft/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+
+# Starknet
+target
+Scarb.lock
+
+# Starknet foundry
+.snfoundry_cache

--- a/experimental/erc_5643_subscription_nft/.tool-versions
+++ b/experimental/erc_5643_subscription_nft/.tool-versions
@@ -1,0 +1,2 @@
+scarb 2.8.4
+starknet-foundry 0.31.0

--- a/experimental/erc_5643_subscription_nft/LICENSE
+++ b/experimental/erc_5643_subscription_nft/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/experimental/erc_5643_subscription_nft/README.md
+++ b/experimental/erc_5643_subscription_nft/README.md
@@ -1,0 +1,43 @@
+<div align="center">
+  <h1 align="center">Cairo ERC-5643 Subscription NFTs</h1>
+  <h3 align="center">Subscription NFTs (ERC-5643) written in Cairo for Starknet.</h3>
+</div>
+
+### About
+
+A Cairo implementation of [EIP-5643](https://eips.ethereum.org/EIPS/eip-5643). EIP-5643 is an Ethereum standard for Subscription NFTs.
+
+> ## ⚠️ WARNING! ⚠️
+>
+> This is repo contains highly experimental code.
+> Expect rapid iteration.
+> **Use at your own risk.**
+
+### Project setup
+
+#### 📦 Requirements
+
+- [scarb](https://docs.swmansion.com/scarb/)
+- [starknet-foundry](https://github.com/foundry-rs/starknet-foundry)
+
+### ⛏️ Compile
+
+```bash
+scarb build
+```
+
+### 💄 Code style
+
+```bash
+scarb fmt
+```
+
+### 🌡️ Test
+
+```bash
+scarb test
+```
+
+## 📄 License
+
+This project is released under the Apache license.

--- a/experimental/erc_5643_subscription_nft/Scarb.toml
+++ b/experimental/erc_5643_subscription_nft/Scarb.toml
@@ -1,0 +1,35 @@
+[package]
+name = "erc_5643_subscription_nft"
+readme = "README.md"
+version = "0.1.0"
+edition = "2024_07"
+cairo-version = "2.8.4"
+scarb-version = "2.8.4"
+authors = ["Flex Marketplace"]
+description = "Subscription NFTs (ERC-5643) written in Cairo for Starknet."
+documentation = "https://github.com/Flex-NFT-Marketplace/Flex-Marketplace-Contract/tree/main/experimental/erc_5643_subscription_nft"
+repository = "https://github.com/Flex-NFT-Marketplace/Flex-Marketplace-Contract"
+license-file = "LICENSE"
+keywords = [
+  "erc5643",
+  "subscription",
+]
+
+[dependencies]
+starknet = "2.8.4"
+openzeppelin_access = "0.18.0"
+openzeppelin_introspection = "0.18.0"
+openzeppelin_token = "0.18.0"
+
+[dev-dependencies]
+assert_macros = "2.8.4"
+openzeppelin_utils = "0.18.0"
+openzeppelin_testing = "0.18.0"
+snforge_std = "0.31.0"
+
+[lib]
+
+[[target.starknet-contract]]
+
+[scripts]
+test = "snforge test"

--- a/experimental/erc_5643_subscription_nft/solidity/src/ERC5643.sol
+++ b/experimental/erc_5643_subscription_nft/solidity/src/ERC5643.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.27;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "./IERC5643.sol";
+
+contract ERC5643 is ERC721, IERC5643 {
+    mapping(uint256 => uint64) private _expirations;
+
+    error SubscriptionNotRenewable();
+
+    constructor(string memory name_, string memory symbol_) ERC721(name_, symbol_) {}
+
+    function renewSubscription(uint256 tokenId, uint64 duration) external payable {
+        _checkAuthorized(_ownerOf(tokenId), msg.sender, tokenId);
+
+        uint64 currentExpiration = _expirations[tokenId];
+        uint64 newExpiration;
+        if (currentExpiration == 0) {
+            newExpiration = uint64(block.timestamp) + duration;
+        } else {
+            if (!isRenewable(tokenId)) {
+                revert SubscriptionNotRenewable();
+            }
+            newExpiration = currentExpiration + duration;
+        }
+
+        _expirations[tokenId] = newExpiration;
+
+        emit SubscriptionUpdate(tokenId, newExpiration);
+    }
+
+    function cancelSubscription(uint256 tokenId) external payable {
+        _checkAuthorized(_ownerOf(tokenId), msg.sender, tokenId);
+        delete _expirations[tokenId];
+        emit SubscriptionUpdate(tokenId, 0);
+    }
+
+    function expiresAt(uint256 tokenId) external view returns(uint64) {
+        return _expirations[tokenId];
+    }
+
+    function isRenewable(uint256) public pure returns(bool) {
+        return true;
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IERC5643).interfaceId || super.supportsInterface(interfaceId);
+    }
+}

--- a/experimental/erc_5643_subscription_nft/solidity/src/IERC5643.sol
+++ b/experimental/erc_5643_subscription_nft/solidity/src/IERC5643.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.27;
+
+interface IERC5643 {
+    /// @notice Emitted when a subscription expiration changes
+    /// @dev When a subscription is canceled, the expiration value should also be 0.
+    event SubscriptionUpdate(uint256 indexed tokenId, uint64 expiration);
+
+    /// @notice Renews the subscription to an NFT
+    /// Throws if `tokenId` is not a valid NFT
+    /// @param tokenId The NFT to renew the subscription for
+    /// @param duration The number of seconds to extend a subscription for
+    function renewSubscription(uint256 tokenId, uint64 duration) external payable;
+
+    /// @notice Cancels the subscription of an NFT
+    /// @dev Throws if `tokenId` is not a valid NFT
+    /// @param tokenId The NFT to cancel the subscription for
+    function cancelSubscription(uint256 tokenId) external payable;
+
+    /// @notice Gets the expiration date of a subscription
+    /// @dev Throws if `tokenId` is not a valid NFT
+    /// @param tokenId The NFT to get the expiration date of
+    /// @return The expiration date of the subscription
+    function expiresAt(uint256 tokenId) external view returns(uint64);
+
+    /// @notice Determines whether a subscription can be renewed
+    /// @dev Throws if `tokenId` is not a valid NFT
+    /// @param tokenId The NFT to get the expiration date of
+    /// @return The renewability of a the subscription
+    function isRenewable(uint256 tokenId) external view returns(bool);
+}

--- a/experimental/erc_5643_subscription_nft/solidity/test/ERC5643.t.sol
+++ b/experimental/erc_5643_subscription_nft/solidity/test/ERC5643.t.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.27;
+
+import "forge-std/Test.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {IERC721Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import "../src/ERC5643.sol";
+
+contract ERC5643Mock is ERC5643 {
+    constructor(string memory name_, string memory symbol_) ERC5643(name_, symbol_) {}
+
+    function mint(address to, uint256 tokenId) public {
+        _mint(to, tokenId);
+    }
+}
+
+contract ERC5643Test is Test {
+    event SubscriptionUpdate(uint256 indexed tokenId, uint64 expiration);
+
+    address user1;
+    uint256 tokenId;
+    ERC5643Mock erc5643;
+
+    function setUp() public {
+        tokenId = 1;
+        user1 = address(0x1);
+
+        erc5643 = new ERC5643Mock("erc5369", "ERC5643");
+        erc5643.mint(user1, tokenId);
+    }
+
+    function testRenewalValid() public {
+        vm.warp(1000);
+        vm.prank(user1);
+        vm.expectEmit(true, true, false, true);
+        emit SubscriptionUpdate(tokenId, 3000);
+        erc5643.renewSubscription(tokenId, 2000);
+    }
+
+    function testRenewalNotOwner() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC721Errors.ERC721InsufficientApproval.selector,
+                address(this),
+                tokenId
+            )
+        );
+        erc5643.renewSubscription(tokenId, 2000);
+    }
+
+    function testCancelValid() public {
+        vm.prank(user1);
+        vm.expectEmit(true, true, false, true);
+        emit SubscriptionUpdate(tokenId, 0);
+        erc5643.cancelSubscription(tokenId);
+    }
+
+    function testCancelNotOwner() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC721Errors.ERC721InsufficientApproval.selector,
+                address(this),
+                tokenId
+            )
+        );
+        erc5643.cancelSubscription(tokenId);
+    }
+
+    function testExpiresAt() public {
+        vm.warp(1000);
+
+        assertEq(erc5643.expiresAt(tokenId), 0);
+        vm.startPrank(user1);
+        erc5643.renewSubscription(tokenId, 2000);
+        assertEq(erc5643.expiresAt(tokenId), 3000);
+
+        erc5643.cancelSubscription(tokenId);
+        assertEq(erc5643.expiresAt(tokenId), 0);
+    }
+}

--- a/experimental/erc_5643_subscription_nft/src/erc5643/erc5643.cairo
+++ b/experimental/erc_5643_subscription_nft/src/erc5643/erc5643.cairo
@@ -1,0 +1,136 @@
+//! Component implementing IERC5643.
+
+#[starknet::component]
+pub mod ERC5643Component {
+    use core::num::traits::Zero;
+    use starknet::{ContractAddress, get_caller_address, get_block_timestamp};
+    use starknet::storage::{
+        Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess
+    };
+    use openzeppelin_introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_token::erc721::ERC721Component::InternalImpl as ERC721InternalImpl;
+    use openzeppelin_token::erc721::ERC721Component::ERC721Impl;
+    use openzeppelin_token::erc721::ERC721Component;
+    use erc_5643_subscription_nft::erc5643::interface::{IERC5643, IERC5643_ID};
+
+    #[storage]
+    pub struct Storage {
+        expirations: Map<u256, u64>,
+    }
+
+    #[event]
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub enum Event {
+        SubscriptionUpdate: SubscriptionUpdate,
+    }
+
+    /// Emitted when `token_id` subscription is updated.
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub struct SubscriptionUpdate {
+        #[key]
+        pub token_id: u256,
+        pub expiration: u64,
+    }
+
+    pub mod Errors {
+        pub const SUBSCRIPTION_NOT_RENEWABLE: felt252 = 'ERC5643: sub not renewable';
+    }
+
+    //
+    // External
+    //
+
+    #[embeddable_as(ERC5643Impl)]
+    impl ERC5643<
+        TContractState,
+        +HasComponent<TContractState>,
+        impl ERC721: ERC721Component::HasComponent<TContractState>,
+        +ERC721Component::ERC721HooksTrait<TContractState>,
+        impl SRC5: SRC5Component::HasComponent<TContractState>,
+        +Drop<TContractState>,
+    > of IERC5643<ComponentState<TContractState>> {
+        fn renew_subscription(
+            ref self: ComponentState<TContractState>, token_id: u256, duration: u64
+        ) {
+            let erc721_component = get_dep_component!(@self, ERC721);
+            let owner = erc721_component.owner_of(token_id);
+            self._check_authorized(owner, get_caller_address(), token_id);
+
+            let current_expiration = self.expirations.entry(token_id).read();
+            let new_expiration = if current_expiration == 0 {
+                get_block_timestamp() + duration
+            } else {
+                assert(self.is_renewable(token_id), Errors::SUBSCRIPTION_NOT_RENEWABLE);
+                current_expiration + duration
+            };
+
+            self.expirations.entry(token_id).write(new_expiration);
+
+            self.emit(SubscriptionUpdate { token_id, expiration: new_expiration });
+        }
+
+        fn cancel_subscription(ref self: ComponentState<TContractState>, token_id: u256) {
+            let erc721_component = get_dep_component!(@self, ERC721);
+            let owner = erc721_component.owner_of(token_id);
+            self._check_authorized(owner, get_caller_address(), token_id);
+            self.expirations.entry(token_id).write(0);
+            self.emit(SubscriptionUpdate { token_id, expiration: 0 });
+        }
+
+        fn expires_at(self: @ComponentState<TContractState>, token_id: u256) -> u64 {
+            self.expirations.entry(token_id).read()
+        }
+
+        fn is_renewable(self: @ComponentState<TContractState>, token_id: u256) -> bool {
+            true
+        }
+    }
+
+    //
+    // Internal
+    //
+
+    #[generate_trait]
+    pub impl InternalImpl<
+        TContractState,
+        +HasComponent<TContractState>,
+        impl ERC721: ERC721Component::HasComponent<TContractState>,
+        +ERC721Component::ERC721HooksTrait<TContractState>,
+        impl SRC5: SRC5Component::HasComponent<TContractState>,
+        +Drop<TContractState>,
+    > of InternalTrait<TContractState> {
+        fn initializer(ref self: ComponentState<TContractState>) {
+            let mut src5_component = get_dep_component_mut!(ref self, SRC5);
+            src5_component.register_interface(IERC5643_ID);
+        }
+
+        fn _is_authorized(
+            self: @ComponentState<TContractState>,
+            owner: ContractAddress,
+            spender: ContractAddress,
+            token_id: u256
+        ) -> bool {
+            let erc721_component = get_dep_component!(self, ERC721);
+            let is_approved_for_all = erc721_component.is_approved_for_all(owner, spender);
+
+            !spender.is_zero()
+                && (owner == spender
+                    || is_approved_for_all
+                    || spender == erc721_component.get_approved(token_id))
+        }
+
+        fn _check_authorized(
+            self: @ComponentState<TContractState>,
+            owner: ContractAddress,
+            spender: ContractAddress,
+            token_id: u256
+        ) {
+            // Non-existent token
+            assert(!owner.is_zero(), ERC721Component::Errors::INVALID_TOKEN_ID);
+            assert(
+                self._is_authorized(owner, spender, token_id), ERC721Component::Errors::UNAUTHORIZED
+            );
+        }
+    }
+}

--- a/experimental/erc_5643_subscription_nft/src/erc5643/erc5643.cairo
+++ b/experimental/erc_5643_subscription_nft/src/erc5643/erc5643.cairo
@@ -57,9 +57,15 @@ pub mod ERC5643Component {
             let owner = erc721_component.owner_of(token_id);
             self._check_authorized(owner, get_caller_address(), token_id);
 
-            let current_expiration = self.expirations.entry(token_id).read();
+            let expiration = self.expirations.entry(token_id).read();
+            let block_timestamp = get_block_timestamp();
+            let current_expiration = if expiration < block_timestamp {
+                block_timestamp
+            } else {
+                expiration
+            };
             let new_expiration = if current_expiration == 0 {
-                get_block_timestamp() + duration
+                block_timestamp + duration
             } else {
                 assert(self.is_renewable(token_id), Errors::SUBSCRIPTION_NOT_RENEWABLE);
                 current_expiration + duration

--- a/experimental/erc_5643_subscription_nft/src/erc5643/interface.cairo
+++ b/experimental/erc_5643_subscription_nft/src/erc5643/interface.cairo
@@ -1,0 +1,24 @@
+pub const IERC5643_ID: felt252 = 0x8c65f84d;
+
+#[starknet::interface]
+pub trait IERC5643<TState> {
+    /// @notice Renews the subscription to an NFT
+    /// Throws if `tokenId` is not a valid NFT
+    /// @param tokenId The NFT to renew the subscription for
+    /// @param duration The number of seconds to extend a subscription for
+    fn renew_subscription(ref self: TState, token_id: u256, duration: u64);
+    /// @notice Cancels the subscription of an NFT
+    /// @dev Throws if `tokenId` is not a valid NFT
+    /// @param tokenId The NFT to cancel the subscription for
+    fn cancel_subscription(ref self: TState, token_id: u256);
+    /// @notice Gets the expiration date of a subscription
+    /// @dev Throws if `tokenId` is not a valid NFT
+    /// @param tokenId The NFT to get the expiration date of
+    /// @return The expiration date of the subscription
+    fn expires_at(self: @TState, token_id: u256) -> u64;
+    /// @notice Determines whether a subscription can be renewed
+    /// @dev Throws if `tokenId` is not a valid NFT
+    /// @param tokenId The NFT to get the expiration date of
+    /// @return The renewability of a the subscription
+    fn is_renewable(self: @TState, token_id: u256) -> bool;
+}

--- a/experimental/erc_5643_subscription_nft/src/lib.cairo
+++ b/experimental/erc_5643_subscription_nft/src/lib.cairo
@@ -1,0 +1,8 @@
+pub mod erc5643 {
+    pub mod erc5643;
+    pub mod interface;
+}
+
+pub mod presets {
+    pub mod erc5643_subscription_nft;
+}

--- a/experimental/erc_5643_subscription_nft/src/presets/erc5643_subscription_nft.cairo
+++ b/experimental/erc_5643_subscription_nft/src/presets/erc5643_subscription_nft.cairo
@@ -1,0 +1,111 @@
+use starknet::ContractAddress;
+
+#[starknet::interface]
+pub trait IERC5643SubscriptionNft<TState> {
+    fn mint(ref self: TState, to: ContractAddress, token_id: u256);
+}
+
+#[starknet::interface]
+pub trait IERC5643SubscriptionNftMixin<TState> {
+    // IERC5643SubscriptionNft
+    fn mint(ref self: TState, to: ContractAddress, token_id: u256);
+    // IERC5643
+    fn renew_subscription(ref self: TState, token_id: u256, duration: u64);
+    fn cancel_subscription(ref self: TState, token_id: u256);
+    fn expires_at(self: @TState, token_id: u256) -> u64;
+    fn is_renewable(self: @TState, token_id: u256) -> bool;
+    // IERC721
+    fn balance_of(self: @TState, account: ContractAddress) -> u256;
+    fn owner_of(self: @TState, token_id: u256) -> ContractAddress;
+    fn safe_transfer_from(
+        ref self: TState,
+        from: ContractAddress,
+        to: ContractAddress,
+        token_id: u256,
+        data: Span<felt252>
+    );
+    fn transfer_from(ref self: TState, from: ContractAddress, to: ContractAddress, token_id: u256);
+    fn approve(ref self: TState, to: ContractAddress, token_id: u256);
+    fn set_approval_for_all(ref self: TState, operator: ContractAddress, approved: bool);
+    fn get_approved(self: @TState, token_id: u256) -> ContractAddress;
+    fn is_approved_for_all(
+        self: @TState, owner: ContractAddress, operator: ContractAddress
+    ) -> bool;
+    // Ownable
+    fn owner(self: @TState) -> ContractAddress;
+    fn transfer_ownership(ref self: TState, new_owner: ContractAddress);
+    fn renounce_ownership(ref self: TState);
+    // ISRC5
+    fn supports_interface(self: @TState, interface_id: felt252) -> bool;
+}
+
+#[starknet::contract]
+pub mod ERC5643SubscriptionNft {
+    use starknet::{ContractAddress, get_caller_address};
+    use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_access::ownable::OwnableComponent;
+    use openzeppelin_token::erc721::{ERC721Component, ERC721HooksEmptyImpl};
+    use erc_5643_subscription_nft::erc5643::erc5643::ERC5643Component;
+
+    component!(path: SRC5Component, storage: src5, event: SRC5Event);
+    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+    component!(path: ERC721Component, storage: erc721, event: ERC721Event);
+    component!(path: ERC5643Component, storage: erc5643, event: ERC5643Event);
+
+    // Ownable
+    #[abi(embed_v0)]
+    impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
+    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+
+    // ERC721Mixin
+    #[abi(embed_v0)]
+    impl ERC721MixinImpl = ERC721Component::ERC721MixinImpl<ContractState>;
+    impl ERC721InternalImpl = ERC721Component::InternalImpl<ContractState>;
+
+    // ERC5643
+    #[abi(embed_v0)]
+    impl ERC5643Impl = ERC5643Component::ERC5643Impl<ContractState>;
+    impl ERC5643InternalImpl = ERC5643Component::InternalImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        src5: SRC5Component::Storage,
+        #[substorage(v0)]
+        ownable: OwnableComponent::Storage,
+        #[substorage(v0)]
+        erc721: ERC721Component::Storage,
+        #[substorage(v0)]
+        erc5643: ERC5643Component::Storage,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        SRC5Event: SRC5Component::Event,
+        #[flat]
+        OwnableEvent: OwnableComponent::Event,
+        #[flat]
+        ERC721Event: ERC721Component::Event,
+        #[flat]
+        ERC5643Event: ERC5643Component::Event,
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState, name: ByteArray, symbol: ByteArray, base_uri: ByteArray
+    ) {
+        self.ownable.initializer(get_caller_address());
+        self.erc721.initializer(name, symbol, base_uri);
+        self.erc5643.initializer();
+    }
+
+    #[abi(embed_v0)]
+    impl ERC5643SubscriptionNftImpl of super::IERC5643SubscriptionNft<ContractState> {
+        fn mint(ref self: ContractState, to: ContractAddress, token_id: u256) {
+            self.ownable.assert_only_owner();
+            self.erc721.mint(to, token_id);
+        }
+    }
+}

--- a/experimental/erc_5643_subscription_nft/tests/erc5643.cairo
+++ b/experimental/erc_5643_subscription_nft/tests/erc5643.cairo
@@ -1,0 +1,93 @@
+use core::panic_with_felt252;
+use snforge_std::{
+    start_cheat_caller_address, start_cheat_block_timestamp, spy_events, EventSpyAssertionsTrait
+};
+use openzeppelin_testing::constants::{OWNER, TOKEN_ID, FAILURE};
+use openzeppelin_token::erc721::ERC721Component;
+use erc_5643_subscription_nft::erc5643::interface::IERC5643_ID;
+use erc_5643_subscription_nft::erc5643::erc5643::ERC5643Component;
+use erc_5643_subscription_nft::presets::erc5643_subscription_nft::{
+    IERC5643SubscriptionNftMixinDispatcherTrait, IERC5643SubscriptionNftMixinSafeDispatcherTrait
+};
+use super::utils::ERC5643TestTrait;
+
+#[test]
+fn test_supports_interface_id() {
+    let erc5643_test = ERC5643TestTrait::setup();
+    assert_eq!(erc5643_test.erc5643_subscription_nft.supports_interface(IERC5643_ID), true);
+}
+
+#[test]
+fn test_renewal_valid() {
+    let erc5643_test = ERC5643TestTrait::setup();
+    start_cheat_block_timestamp(erc5643_test.erc5643_subscription_nft_address, 1000);
+    start_cheat_caller_address(erc5643_test.erc5643_subscription_nft_address, OWNER());
+    let mut spy = spy_events();
+    erc5643_test.erc5643_subscription_nft.renew_subscription(TOKEN_ID, 2000);
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    erc5643_test.erc5643_subscription_nft_address,
+                    ERC5643Component::Event::SubscriptionUpdate(
+                        ERC5643Component::SubscriptionUpdate {
+                            token_id: TOKEN_ID, expiration: 3000,
+                        }
+                    )
+                )
+            ]
+        );
+}
+
+#[test]
+fn test_renewal_not_owner() {
+    let erc5643_test = ERC5643TestTrait::setup();
+    match erc5643_test.erc5643_subscription_nft_safe.renew_subscription(TOKEN_ID, 2000) {
+        Result::Ok(_) => panic_with_felt252(FAILURE),
+        Result::Err(panic_data) => {
+            assert_eq!(*panic_data.at(0), ERC721Component::Errors::UNAUTHORIZED);
+        }
+    }
+}
+
+#[test]
+fn test_cancel_valid() {
+    let erc5643_test = ERC5643TestTrait::setup();
+    start_cheat_caller_address(erc5643_test.erc5643_subscription_nft_address, OWNER());
+    let mut spy = spy_events();
+    erc5643_test.erc5643_subscription_nft.cancel_subscription(TOKEN_ID);
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    erc5643_test.erc5643_subscription_nft_address,
+                    ERC5643Component::Event::SubscriptionUpdate(
+                        ERC5643Component::SubscriptionUpdate { token_id: TOKEN_ID, expiration: 0, }
+                    )
+                )
+            ]
+        );
+}
+
+#[test]
+fn test_cancel_not_owner() {
+    let erc5643_test = ERC5643TestTrait::setup();
+    match erc5643_test.erc5643_subscription_nft_safe.cancel_subscription(TOKEN_ID) {
+        Result::Ok(_) => panic_with_felt252(FAILURE),
+        Result::Err(panic_data) => {
+            assert_eq!(*panic_data.at(0), ERC721Component::Errors::UNAUTHORIZED);
+        }
+    }
+}
+
+#[test]
+fn test_expires_at() {
+    let erc5643_test = ERC5643TestTrait::setup();
+    start_cheat_block_timestamp(erc5643_test.erc5643_subscription_nft_address, 1000);
+    assert_eq!(erc5643_test.erc5643_subscription_nft.expires_at(TOKEN_ID), 0);
+    start_cheat_caller_address(erc5643_test.erc5643_subscription_nft_address, OWNER());
+    erc5643_test.erc5643_subscription_nft.renew_subscription(TOKEN_ID, 2000);
+    assert_eq!(erc5643_test.erc5643_subscription_nft.expires_at(TOKEN_ID), 3000);
+    erc5643_test.erc5643_subscription_nft.cancel_subscription(TOKEN_ID);
+    assert_eq!(erc5643_test.erc5643_subscription_nft.expires_at(TOKEN_ID), 0);
+}

--- a/experimental/erc_5643_subscription_nft/tests/erc5643.cairo
+++ b/experimental/erc_5643_subscription_nft/tests/erc5643.cairo
@@ -91,3 +91,14 @@ fn test_expires_at() {
     erc5643_test.erc5643_subscription_nft.cancel_subscription(TOKEN_ID);
     assert_eq!(erc5643_test.erc5643_subscription_nft.expires_at(TOKEN_ID), 0);
 }
+
+#[test]
+fn test_expired_subscription() {
+    let erc5643_test = ERC5643TestTrait::setup();
+    start_cheat_block_timestamp(erc5643_test.erc5643_subscription_nft_address, 1000);
+    start_cheat_caller_address(erc5643_test.erc5643_subscription_nft_address, OWNER());
+    erc5643_test.erc5643_subscription_nft.renew_subscription(TOKEN_ID, 2000);
+    start_cheat_block_timestamp(erc5643_test.erc5643_subscription_nft_address, 4000);
+    erc5643_test.erc5643_subscription_nft.renew_subscription(TOKEN_ID, 2000);
+    assert_eq!(erc5643_test.erc5643_subscription_nft.expires_at(TOKEN_ID), 6000);
+}

--- a/experimental/erc_5643_subscription_nft/tests/lib.cairo
+++ b/experimental/erc_5643_subscription_nft/tests/lib.cairo
@@ -1,0 +1,4 @@
+#[cfg(test)]
+#[feature("safe_dispatcher")]
+mod erc5643;
+mod utils;

--- a/experimental/erc_5643_subscription_nft/tests/utils.cairo
+++ b/experimental/erc_5643_subscription_nft/tests/utils.cairo
@@ -1,0 +1,40 @@
+use starknet::ContractAddress;
+use openzeppelin_utils::serde::SerializedAppend;
+use openzeppelin_testing::constants::{NAME, SYMBOL, BASE_URI, OWNER, TOKEN_ID};
+use openzeppelin_testing::deployment::declare_and_deploy;
+use erc_5643_subscription_nft::presets::erc5643_subscription_nft::{
+    IERC5643SubscriptionNftMixinDispatcher, IERC5643SubscriptionNftMixinDispatcherTrait,
+    IERC5643SubscriptionNftMixinSafeDispatcher,
+};
+
+#[derive(Copy, Drop)]
+pub struct ERC5643Test {
+    pub erc5643_subscription_nft_address: ContractAddress,
+    pub erc5643_subscription_nft: IERC5643SubscriptionNftMixinDispatcher,
+    pub erc5643_subscription_nft_safe: IERC5643SubscriptionNftMixinSafeDispatcher,
+}
+
+#[generate_trait]
+pub impl ERC5643TestImpl of ERC5643TestTrait {
+    fn setup() -> ERC5643Test {
+        let mut erc5643_subscription_nft_calldata = array![];
+        erc5643_subscription_nft_calldata.append_serde(NAME());
+        erc5643_subscription_nft_calldata.append_serde(SYMBOL());
+        erc5643_subscription_nft_calldata.append_serde(BASE_URI());
+        let erc5643_subscription_nft_address = declare_and_deploy(
+            "ERC5643SubscriptionNft", erc5643_subscription_nft_calldata
+        );
+        let erc5643_subscription_nft = IERC5643SubscriptionNftMixinDispatcher {
+            contract_address: erc5643_subscription_nft_address
+        };
+        let erc5643_subscription_nft_safe = IERC5643SubscriptionNftMixinSafeDispatcher {
+            contract_address: erc5643_subscription_nft_address
+        };
+        erc5643_subscription_nft.mint(OWNER(), TOKEN_ID);
+        ERC5643Test {
+            erc5643_subscription_nft_address,
+            erc5643_subscription_nft,
+            erc5643_subscription_nft_safe,
+        }
+    }
+}


### PR DESCRIPTION
This PR implements ERC-5643 as a Cairo component along with tests to validate the implementation.
It is based from a reference implementation of this EIP: https://eips.ethereum.org/EIPS/eip-5643
The Solidity reference implementation has been added as a case study on how to port Solidity code to Cairo.

Fix #124 